### PR TITLE
カジノ系のオーバーフローを修正

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    compile     'net.dv8tion:JDA:4.3.0_346'
+    compile     'net.dv8tion:JDA:4.4.0_350'
     compile     'club.minnced:opus-java-api:1.1.0'
     compile     'club.minnced:opus-java-natives:1.1.0'
     compile    ('club.minnced:opus-java:1.1.0@pom') {transitive = true}

--- a/src/main/java/xyz/n7mn/dev/Command/Aisatu.java
+++ b/src/main/java/xyz/n7mn/dev/Command/Aisatu.java
@@ -44,7 +44,7 @@ public class Aisatu extends Chat {
             builder.setImage("https://nana-bot.n7mn.xyz/irasutoya/" + ohaList[i]);
             builder.setFooter("素材元：いらすとや");
 
-            getTextChannel().sendMessage(builder.build()).queue();
+            getTextChannel().sendMessageEmbeds(builder.build()).queue();
             return;
         }
 
@@ -56,7 +56,7 @@ public class Aisatu extends Chat {
             builder.setImage("https://nana-bot.n7mn.xyz/irasutoya/" + oyaList[i]);
             builder.setFooter("素材元：いらすとや");
 
-            getTextChannel().sendMessage(builder.build()).queue();
+            getTextChannel().sendMessageEmbeds(builder.build()).queue();
             return;
         }
 
@@ -90,7 +90,7 @@ public class Aisatu extends Chat {
 
         getMessage().delete().queue();
 
-        getTextChannel().sendMessage(msg).embed(builder.build()).queue(message -> {
+        getTextChannel().sendMessage(msg).setEmbeds(builder.build()).queue(message -> {
             message.addReaction(emoji).queue();
         });
 

--- a/src/main/java/xyz/n7mn/dev/Command/CheckCommand.java
+++ b/src/main/java/xyz/n7mn/dev/Command/CheckCommand.java
@@ -76,12 +76,12 @@ public class CheckCommand extends Chat {
                         }
                     }
                     builder.setFooter("テストに "+(System.currentTimeMillis() - startTime)+"msかかったらしいですっ....？");
-                    message.editMessage(builder.build()).queue();
+                    message.editMessageEmbeds(builder.build()).queue();
                 });
             } else {
                 builder.addField("ななみちゃん設定チャンネル","なし", false);
                 builder.setFooter("テストに "+(System.currentTimeMillis() - startTime)+"msかかったらしいですっ....？");
-                message.editMessage(builder.build()).queue();
+                message.editMessageEmbeds(builder.build()).queue();
             }
         });
     }

--- a/src/main/java/xyz/n7mn/dev/Command/CommandSystem.java
+++ b/src/main/java/xyz/n7mn/dev/Command/CommandSystem.java
@@ -245,7 +245,7 @@ public class CommandSystem {
             builder.addField("内容", messageText, false);
             builder.addField("メッセージリンクURL", message.getJumpUrl(), false);
 
-            user.openPrivateChannel().complete().sendMessage(builder.build()).queue();
+            user.openPrivateChannel().complete().sendMessageEmbeds(builder.build()).queue();
         }
 
         if (system != null){

--- a/src/main/java/xyz/n7mn/dev/Command/Game.java
+++ b/src/main/java/xyz/n7mn/dev/Command/Game.java
@@ -16,6 +16,6 @@ public class Game extends xyz.n7mn.dev.i.Game {
         builder.setTitle(Help.getHelpData(9).getHelpTitle());
         builder.setDescription(Help.getHelpData(9).getHelpMessage());
 
-        getMessage().reply(builder.build()).queue();
+        getMessage().replyEmbeds(builder.build()).queue();
     }
 }

--- a/src/main/java/xyz/n7mn/dev/Command/GameFx.java
+++ b/src/main/java/xyz/n7mn/dev/Command/GameFx.java
@@ -6,6 +6,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import xyz.n7mn.dev.Command.money.Money;
 import xyz.n7mn.dev.Command.money.MoneySystem;
+import xyz.n7mn.dev.Command.money.MoneyUtil;
 import xyz.n7mn.dev.i.Game;
 
 import java.security.SecureRandom;
@@ -22,16 +23,16 @@ public class GameFx extends Game {
 
         Money money = MoneySystem.getData(getMessage().getMember().getId());
 
-        if (money == null){
+        if (money == null) {
             money = MoneySystem.getDefaultData(getMember().getId());
             MoneySystem.createData(money.getUserID());
         }
 
-        if (!text.equals("n.fx") && textSplit.length == 1){
+        if (!text.equals("n.fx") && textSplit.length == 1) {
             return;
         }
 
-        if (textSplit.length != 2){
+        if (textSplit.length != 2) {
             getMessage().reply("えらーですっ！\n`n.fx <掛け金>`で実行してください！").queue();
             return;
         }
@@ -39,16 +40,16 @@ public class GameFx extends Game {
         long useMoney = -1;
         try {
             useMoney = Long.parseLong(textSplit[1]);
-        } catch (Exception e){
+        } catch (Exception e) {
             // e.printStackTrace();
         }
 
-        if (money.getMoney() <= useMoney){
+        if (money.getMoney() <= useMoney) {
             getMessage().reply("所持金が足りないですっ！").queue();
             return;
         }
 
-        if (useMoney <= 0){
+        if (useMoney <= 0) {
             getMessage().reply("それはおかしいですよ...").queue();
             return;
         }
@@ -57,68 +58,68 @@ public class GameFx extends Game {
 
         StringBuffer sb = new StringBuffer();
         int b = 1;
-        if (useMoney < 100){
+        if (useMoney < 100) {
             sb.append("元値 2倍もーど！\n");
             b = 2;
         }
 
-        if (useMoney >= 100 && useMoney < 1000){
+        if (useMoney >= 100 && useMoney < 1000) {
             sb.append("元値 5倍もーど！\n");
             b = 5;
         }
 
-        if (useMoney >= 1000 && useMoney < 10000){
+        if (useMoney >= 1000 && useMoney < 10000) {
             sb.append("元値 10倍もーど！\n");
             b = 10;
         }
 
-        if (useMoney >= 10000 && useMoney < 100000){
+        if (useMoney >= 10000 && useMoney < 100000) {
             sb.append("元値 20倍もーど！\n");
             b = 20;
         }
 
-        if (useMoney >= 100000 && useMoney < 1000000){
+        if (useMoney >= 100000 && useMoney < 1000000) {
             sb.append("元値 40倍もーど！\n");
             b = 40;
         }
 
-        if (useMoney >= 1000000 && useMoney < 10000000){
+        if (useMoney >= 1000000 && useMoney < 10000000) {
             sb.append("元値 80倍もーど！\n");
             b = 80;
         }
 
-        if (useMoney >= 10000000 && useMoney < 100000000){
+        if (useMoney >= 10000000 && useMoney < 100000000) {
             sb.append("元値 160倍もーど！\n");
             b = 160;
         }
 
-        if (useMoney >= 100000000){
+        if (useMoney >= 100000000) {
             sb.append("元値 320倍もーど！\n");
             b = 320;
         }
-        long mo = useMoney * b;
-        long mo2 = useMoney * b;
+        long mo = MoneyUtil.multiply(useMoney, b);
+        long mo2 = MoneyUtil.multiply(useMoney, b);
         sb.append(mo);
         sb.append(" ");
         sb.append(MoneySystem.getCurrency());
         sb.append("を元値にFX開始っ！！\n");
 
 
-        for (int i = 0; i < 5; i++){
+        for (int i = 0; i < 5; i++) {
 
             sb.append((i + 1));
             sb.append("回目：");
 
             long rr = mo2 * 2;
             long n = Math.abs(new SecureRandom().nextLong() % rr);
-            if (new SecureRandom().nextBoolean()){
-                mo = mo + n;
+            if (new SecureRandom().nextBoolean()) {
+                mo = MoneyUtil.add(mo, n, true);
                 sb.append(n);
                 sb.append(" ");
                 sb.append(MoneySystem.getCurrency());
                 sb.append(" あがったよ！\n");
             } else {
-                mo = mo - n;
+                mo = MoneyUtil.subtract(mo, n, false);
                 sb.append(n);
                 sb.append(" ");
                 sb.append(MoneySystem.getCurrency());
@@ -132,17 +133,19 @@ public class GameFx extends Game {
         sb.append(MoneySystem.getCurrency());
         sb.append("になったよ！\n\n");
 
-        mo = mo - mo2;
+        mo = MoneyUtil.subtract(mo, mo2, false);
         sb.append("(");
         sb.append(mo);
         sb.append(MoneySystem.getCurrency());
         sb.append("獲得しました！)");
 
-        if (nowMoney == Long.MAX_VALUE){
+        long tempLong = mo > 0 ? MoneyUtil.add(nowMoney, mo, true) : MoneyUtil.add(nowMoney, mo, false);
+
+        if (tempLong == Long.MAX_VALUE) {
             sb.append("\n(所持金が保有上限を超えたため、一部は他の方への借金地獄対策のための資金とさせていただきましたっ)");
         }
 
-        MoneySystem.updateData(new Money(money.getUserID(), nowMoney));
+        MoneySystem.updateData(new Money(money.getUserID(), tempLong));
         getMessage().reply(sb.toString()).queue();
     }
 }

--- a/src/main/java/xyz/n7mn/dev/Command/GameNoMoney.java
+++ b/src/main/java/xyz/n7mn/dev/Command/GameNoMoney.java
@@ -1,6 +1,5 @@
 package xyz.n7mn.dev.Command;
 
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import xyz.n7mn.dev.Command.money.Money;

--- a/src/main/java/xyz/n7mn/dev/Command/GameNomoney2.java
+++ b/src/main/java/xyz/n7mn/dev/Command/GameNomoney2.java
@@ -6,7 +6,6 @@ import xyz.n7mn.dev.Command.money.Money;
 import xyz.n7mn.dev.Command.money.MoneySystem;
 import xyz.n7mn.dev.i.Game;
 
-import java.math.BigDecimal;
 import java.security.SecureRandom;
 
 public class GameNomoney2 extends Game {
@@ -19,7 +18,7 @@ public class GameNomoney2 extends Game {
         String text = getMessage().getContentRaw();
         String[] textSplit = text.split(" ", -1);
 
-        if (textSplit.length == 1 && !text.toLowerCase().equals("n.nomoney2")){
+        if (textSplit.length == 1 && !text.equalsIgnoreCase("n.nomoney2")){
             return;
         }
 

--- a/src/main/java/xyz/n7mn/dev/Command/GameOmikuji.java
+++ b/src/main/java/xyz/n7mn/dev/Command/GameOmikuji.java
@@ -1,12 +1,12 @@
 package xyz.n7mn.dev.Command;
 
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import xyz.n7mn.dev.Command.game.Omikuji;
 import xyz.n7mn.dev.Command.game.OmikujiSystem;
 import xyz.n7mn.dev.Command.money.Money;
 import xyz.n7mn.dev.Command.money.MoneySystem;
+import xyz.n7mn.dev.Command.money.MoneyUtil;
 
 import java.security.SecureRandom;
 import java.util.List;
@@ -22,15 +22,15 @@ public class GameOmikuji extends xyz.n7mn.dev.i.Game {
 
         List<Omikuji> omikujiData = OmikujiSystem.getOmikujiData(getGuild());
         Money money = MoneySystem.getData(getMember().getId());
-        if (money == null){
+        if (money == null) {
             money = MoneySystem.getDefaultData(getMember().getId());
         }
 
         SecureRandom secureRandom = new SecureRandom();
         int i = secureRandom.nextInt(omikujiData.size() - 1);
 
-        long tempInt = money.getMoney() + omikujiData.get(i).getCoins();
-        MoneySystem.updateData(new Money(money.getUserID(), tempInt));
-        getMessage().reply(omikujiData.get(i).getResultComment() + "\nあなたの運勢は "+omikujiData.get(i).getResultText()+" でした！\n(獲得コインは"+omikujiData.get(i).getCoins()+"です。)").queue();
+        long tempLong = MoneyUtil.add(money.getMoney(), omikujiData.get(i).getCoins(), true);
+        MoneySystem.updateData(new Money(money.getUserID(), tempLong));
+        getMessage().reply(omikujiData.get(i).getResultComment() + "\nあなたの運勢は " + omikujiData.get(i).getResultText() + " でした！\n(獲得コインは" + omikujiData.get(i).getCoins() + "です。)").queue();
     }
 }

--- a/src/main/java/xyz/n7mn/dev/Command/GameRank.java
+++ b/src/main/java/xyz/n7mn/dev/Command/GameRank.java
@@ -70,6 +70,6 @@ public class GameRank extends Game {
         }
 
         builder.addField("あなたの順位",sendRank + " 位 ("+moneyList.get(sendC).getMoney()+"コイン)", false);
-        getMessage().reply(builder.build()).queue();
+        getMessage().replyEmbeds(builder.build()).queue();
     }
 }

--- a/src/main/java/xyz/n7mn/dev/Command/GameSlot.java
+++ b/src/main/java/xyz/n7mn/dev/Command/GameSlot.java
@@ -5,6 +5,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import xyz.n7mn.dev.Command.money.Money;
 import xyz.n7mn.dev.Command.money.MoneySystem;
+import xyz.n7mn.dev.Command.money.MoneyUtil;
 import xyz.n7mn.dev.i.Game;
 
 import java.security.SecureRandom;
@@ -66,8 +67,8 @@ public class GameSlot extends Game {
             flag = true;
         }
 
-        long tempInt = (money.getMoney() + plus);
-        MoneySystem.updateData(new Money(money.getUserID(), tempInt));
+        long tempLong = MoneyUtil.add(money.getMoney(), plus, true);
+        MoneySystem.updateData(new Money(money.getUserID(), tempLong));
 
         if (flag){
             getMessage().reply("あたり！ "+ (plus / but) + "倍！\nスロット結果 ： `"+a.get(slot1)+" "+b.get(slot2)+" "+c.get(slot3)+"`").queue();

--- a/src/main/java/xyz/n7mn/dev/Command/GameYoso.java
+++ b/src/main/java/xyz/n7mn/dev/Command/GameYoso.java
@@ -66,12 +66,11 @@ public class GameYoso extends Game {
 
                     MoneySystem.updateData(new Money(money.getUserID(), tempInt));
                     getMessage().reply("あたりっ！！\n予想数字：" + textSplit[2]+"\n"+"結果：" + i + "\n("+(Integer.parseInt(textSplit[1]) * 10)+MoneySystem.getCurrency()+"獲得しました。)").queue();
-                    return;
                 } else {
                     MoneySystem.updateData(new Money(money.getUserID(),  nowMoney - Integer.parseInt(textSplit[1])));
                     getMessage().reply("はずれです...\n予想数字：" + textSplit[2]+"\n"+"結果：" + i + "").queue();
-                    return;
                 }
+                return;
 
             } catch (Exception e) {
                 // e.printStackTrace();

--- a/src/main/java/xyz/n7mn/dev/Command/Help.java
+++ b/src/main/java/xyz/n7mn/dev/Command/Help.java
@@ -390,7 +390,7 @@ public class Help extends Chat {
             builder.addField(extHelp.getHelpTitle(), extHelp.getHelpMessage(), false);
 
             PrivateChannel sendUserDM = getUser().openPrivateChannel().complete();
-            sendUserDM.sendMessage(builder.build()).queue();
+            sendUserDM.sendMessageEmbeds(builder.build()).queue();
             getMessage().reply("ななみちゃんbotのヘルプをDMにお送りいたしましたっ！\n(もっと詳細なヘルプが欲しい場合は`n.vote`、`n.game`、`n.quiz`、`n.help <コマンド名(n.除く)>`のどれかを実行してくださいっ！！)").queue();
         } else {
             String[] text = getMessageText().split(" ", -1);
@@ -404,7 +404,7 @@ public class Help extends Chat {
                     builder.setDescription(text[1] + "の詳細ヘルプを表示しますっ");
                     builder.addField(help.getHelpTitle(), help.getHelpMessage(), false);
                     PrivateChannel sendUserDM = getUser().openPrivateChannel().complete();
-                    sendUserDM.sendMessage(builder.build()).queue();
+                    sendUserDM.sendMessageEmbeds(builder.build()).queue();
                     getMessage().reply("ななみちゃんbotのコマンド詳細ヘルプをDMにお送りいたしましたっ！").queue();
                     return;
                 }
@@ -450,7 +450,7 @@ public class Help extends Chat {
 
             HelpData extHelp = getHelpData(2000);
             builder.addField(extHelp.getHelpTitle(), extHelp.getHelpMessage(), false);
-            channel.sendMessage(builder.build()).queue();
+            channel.sendMessageEmbeds(builder.build()).queue();
         } else {
             String[] textSplit = text.split(" ", -1);
             if (textSplit.length != 2){
@@ -466,7 +466,7 @@ public class Help extends Chat {
                         builder.setDescription(textSplit[1] + "の詳細ヘルプを表示しますっ");
                     }
                     builder.addField(help.getHelpTitle(), help.getHelpMessage(), false);
-                    channel.sendMessage(builder.build()).queue();
+                    channel.sendMessageEmbeds(builder.build()).queue();
                     return;
                 }
             }

--- a/src/main/java/xyz/n7mn/dev/Command/MoneyCommand.java
+++ b/src/main/java/xyz/n7mn/dev/Command/MoneyCommand.java
@@ -5,6 +5,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import xyz.n7mn.dev.Command.money.Money;
 import xyz.n7mn.dev.Command.money.MoneySystem;
+import xyz.n7mn.dev.Command.money.MoneyUtil;
 import xyz.n7mn.dev.i.Game;
 
 import java.util.List;
@@ -75,8 +76,8 @@ public class MoneyCommand extends Game {
                         MoneySystem.createData(targetMember.getId());
                     }
 
-                    long temp = targetMoney.getMoney() + Long.parseLong(split[3]);
-                    if (!(temp < Long.MAX_VALUE)){
+                    long temp = MoneyUtil.add(targetMoney.getMoney(), Long.parseLong(split[3]), true);
+                    if (temp == Long.MAX_VALUE){
                         getMessage().reply("相手は上限に達していますっ！！").queue();
                         return;
                     }

--- a/src/main/java/xyz/n7mn/dev/Command/Msg.java
+++ b/src/main/java/xyz/n7mn/dev/Command/Msg.java
@@ -72,7 +72,7 @@ public class Msg extends Chat {
                                         "編集済みかどうか : " + edited + "\n" +
                                         "投稿者 : " + author.getAsTag() + "\n" +
                                         "添付ファイルの数 : " + attachments.size() + "\n"
-                        ).embed(build).queue();
+                        ).setEmbeds(build).queue();
                     } catch (Exception e){
                         getMessage().reply("メッセージが存在しませんっ！").queue();
                     }
@@ -115,7 +115,7 @@ public class Msg extends Chat {
                             "編集済みかどうか : " + edited + "\n" +
                             "投稿者 : " + author.getAsTag() + "\n" +
                             "添付ファイルの数 : " + attachments.size() + "\n"
-            ).embed(build).queue();
+            ).setEmbeds(build).queue();
         });
 
     }

--- a/src/main/java/xyz/n7mn/dev/Command/Music.java
+++ b/src/main/java/xyz/n7mn/dev/Command/Music.java
@@ -34,6 +34,6 @@ public class Music extends Chat {
         );
         builder.setColor(Color.PINK);
 
-        getMessage().reply("音楽機能でできることはこちらっ！").embed(builder.build()).queue();
+        getMessage().reply("音楽機能でできることはこちらっ！").setEmbeds(builder.build()).queue();
     }
 }

--- a/src/main/java/xyz/n7mn/dev/Command/MusicPlay.java
+++ b/src/main/java/xyz/n7mn/dev/Command/MusicPlay.java
@@ -5,7 +5,6 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.VoiceChannel;
 import net.dv8tion.jda.api.managers.AudioManager;
-import xyz.n7mn.dev.Command.music.GuildMusicManager;
 import xyz.n7mn.dev.Command.music.PlayerManager;
 import xyz.n7mn.dev.i.Chat;
 import xyz.n7mn.dev.i.HelpData;

--- a/src/main/java/xyz/n7mn/dev/Command/MusicRepeat.java
+++ b/src/main/java/xyz/n7mn/dev/Command/MusicRepeat.java
@@ -3,6 +3,7 @@ package xyz.n7mn.dev.Command;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.managers.AudioManager;
+import xyz.n7mn.dev.Command.music.GuildMusicManager;
 import xyz.n7mn.dev.Command.music.PlayerManager;
 import xyz.n7mn.dev.i.Chat;
 import xyz.n7mn.dev.i.HelpData;
@@ -24,12 +25,15 @@ public class MusicRepeat extends Chat {
 
         if (audioManager.isConnected()){
 
-            PlayerManager Playermanager = PlayerManager.getINSTANCE();
-            Playermanager.Repeat(getTextChannel());
-            return;
+            GuildMusicManager guildMusicManager = PlayerManager.getINSTANCE().getGuildMusicManager(getGuild());
 
+            boolean repeat = !guildMusicManager.scheduler.repeat;
+
+            getMessage().reply(repeat ? "1曲ループモードになりましたっ！" : "1曲ループモードをやめましたっ！").queue();
+
+            guildMusicManager.scheduler.repeat = repeat;
+        } else {
+            getMessage().reply("現在再生していません！").queue();
         }
-
-        getMessage().reply("現在再生していません！").queue();
     }
 }

--- a/src/main/java/xyz/n7mn/dev/Command/MusicSkip.java
+++ b/src/main/java/xyz/n7mn/dev/Command/MusicSkip.java
@@ -1,7 +1,6 @@
 package xyz.n7mn.dev.Command;
 
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.managers.AudioManager;

--- a/src/main/java/xyz/n7mn/dev/Command/MusicStop.java
+++ b/src/main/java/xyz/n7mn/dev/Command/MusicStop.java
@@ -1,6 +1,5 @@
 package xyz.n7mn.dev.Command;
 
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.managers.AudioManager;
@@ -8,8 +7,6 @@ import xyz.n7mn.dev.Command.music.GuildMusicManager;
 import xyz.n7mn.dev.Command.music.PlayerManager;
 import xyz.n7mn.dev.i.Chat;
 import xyz.n7mn.dev.i.HelpData;
-
-import java.awt.*;
 
 public class MusicStop extends Chat {
     public MusicStop(TextChannel textChannel, Message message) {

--- a/src/main/java/xyz/n7mn/dev/Command/MusicVolume.java
+++ b/src/main/java/xyz/n7mn/dev/Command/MusicVolume.java
@@ -4,7 +4,6 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.managers.AudioManager;
-import xyz.n7mn.dev.Command.music.GuildMusicManager;
 import xyz.n7mn.dev.Command.music.PlayerManager;
 import xyz.n7mn.dev.i.Chat;
 import xyz.n7mn.dev.i.HelpData;

--- a/src/main/java/xyz/n7mn/dev/Command/Ping.java
+++ b/src/main/java/xyz/n7mn/dev/Command/Ping.java
@@ -34,7 +34,7 @@ public class Ping extends Chat {
                     builder.addField("n.pingが送信された日時", sdf.format(fromDate),false);
                     builder.addField("ななみちゃんが送信した日時", sdf.format(toDate), false);
                     builder.addField("n.pingが送信されてから応答するまでの時間", (toDate.getTime() - fromDate.getTime()) + "ms", false);
-                    message.editMessage("応答したよっ").embed(builder.build()).queue();
+                    message.editMessage("応答したよっ").setEmbeds(builder.build()).queue();
 
                 }
         );

--- a/src/main/java/xyz/n7mn/dev/Command/Random.java
+++ b/src/main/java/xyz/n7mn/dev/Command/Random.java
@@ -27,8 +27,7 @@ public class Random extends Chat {
         SecureRandom secureRandom = new SecureRandom();
 
         String[] split = getMessageText().split(" ", -1);
-        List<String> wordList = new ArrayList<>();
-        wordList.addAll(Arrays.asList(split).subList(1, split.length));
+        List<String> wordList = new ArrayList<>(Arrays.asList(split).subList(1, split.length));
 
         shuffle(wordList);
 

--- a/src/main/java/xyz/n7mn/dev/Command/Role.java
+++ b/src/main/java/xyz/n7mn/dev/Command/Role.java
@@ -115,7 +115,7 @@ public class Role extends Chat {
 
 
 
-            getMessage().reply(builder.build()).queue(message -> {
+            getMessage().replyEmbeds(builder.build()).queue(message -> {
                 message.addReaction("\u2705").queue();
                 message.addReaction("\u274C").queue();
             });

--- a/src/main/java/xyz/n7mn/dev/Command/SebunkuCommand.java
+++ b/src/main/java/xyz/n7mn/dev/Command/SebunkuCommand.java
@@ -47,7 +47,7 @@ public class SebunkuCommand extends Chat {
                 builder.setThumbnail("https://nana-bot.n7mn.xyz/sebunku/body.png");
                 builder.setImage(sebunku.get(i).getImageURL());
                 builder.setColor(Color.PINK);
-                getTextChannel().sendMessage(builder.build()).queue();
+                getTextChannel().sendMessageEmbeds(builder.build()).queue();
                 return;
             }
 

--- a/src/main/java/xyz/n7mn/dev/Command/URLChecker.java
+++ b/src/main/java/xyz/n7mn/dev/Command/URLChecker.java
@@ -51,7 +51,7 @@ public class URLChecker extends Chat {
             builder.setColor(Color.ORANGE);
             getMessage().addReaction("\uD83D\uDCBE").queue();
 
-            getTextChannel().sendMessage(builder.build()).queue();
+            getTextChannel().sendMessageEmbeds(builder.build()).queue();
         }
 
     }

--- a/src/main/java/xyz/n7mn/dev/Command/Vote.java
+++ b/src/main/java/xyz/n7mn/dev/Command/Vote.java
@@ -40,7 +40,7 @@ public class Vote extends Chat {
             HelpData message = getHelpMessage();
             builder.addField(message.getHelpTitle(), message.getHelpMessage(), false).setColor(Color.CYAN);
 
-            getMessage().reply(builder.build()).queue();
+            getMessage().replyEmbeds(builder.build()).queue();
             return;
         }
 
@@ -187,7 +187,7 @@ public class Vote extends Chat {
         //start = System.currentTimeMillis();
         getMessage().delete().queue();
         //long finalStart = start;
-        getTextChannel().sendMessage(builder.build()).queue(message -> {
+        getTextChannel().sendMessageEmbeds(builder.build()).queue(message -> {
             for (VoteRegionalData voteData : voteRegionalDataList){
                 message.addReaction(voteData.getEmoji()).queue();
             }

--- a/src/main/java/xyz/n7mn/dev/Command/VoteCheck.java
+++ b/src/main/java/xyz/n7mn/dev/Command/VoteCheck.java
@@ -86,7 +86,7 @@ public class VoteCheck extends Chat {
                 builder.setDescription(sb.toString());
 
                 PrivateChannel sendUserDM = getUser().openPrivateChannel().complete();
-                sendUserDM.sendMessage(builder.build()).queue();
+                sendUserDM.sendMessageEmbeds(builder.build()).queue();
                 getMessage().reply("途中結果をお送りしましたっ").queue();
             });
         } catch (Exception e){

--- a/src/main/java/xyz/n7mn/dev/Command/VoteStop.java
+++ b/src/main/java/xyz/n7mn/dev/Command/VoteStop.java
@@ -12,7 +12,7 @@ import xyz.n7mn.dev.i.HelpData;
 
 public class VoteStop extends Chat {
 
-    private EmbedBuilder builder = new EmbedBuilder();
+    private final EmbedBuilder builder = new EmbedBuilder();
 
     public VoteStop(TextChannel textChannel, Message message) {
         super(textChannel, message);
@@ -28,7 +28,7 @@ public class VoteStop extends Chat {
 
         String[] textSplit = getMessageText().split(" ", -1);
 
-        if (textSplit.length == 1 && !getMessageText().toLowerCase().equals("n.stopvote")){
+        if (textSplit.length == 1 && !getMessageText().equalsIgnoreCase("n.stopvote")){
             return;
         }
 

--- a/src/main/java/xyz/n7mn/dev/Command/YululiCommand.java
+++ b/src/main/java/xyz/n7mn/dev/Command/YululiCommand.java
@@ -42,7 +42,7 @@ public class YululiCommand extends Chat {
             builder.setImage(imageDataList.get(i).getImageURL());
             builder.setColor(Color.YELLOW);
 
-            getTextChannel().sendMessage(imageDataList.get(i).getImageURL()).embed(builder.build()).queue(message -> {
+            getTextChannel().sendMessage(imageDataList.get(i).getImageURL()).setEmbeds(builder.build()).queue(message -> {
                 message.addReaction("\uD83D\uDCAF").queue();
             });
             return;
@@ -139,7 +139,7 @@ public class YululiCommand extends Chat {
             builder.setImage(imageDataList.get(i).getImageURL());
             builder.setColor(Color.ORANGE);
 
-            getTextChannel().sendMessage(builder.build()).queue(message -> {
+            getTextChannel().sendMessageEmbeds(builder.build()).queue(message -> {
                 message.addReaction("\uD83D\uDCAF").queue();
             });
             return;
@@ -160,7 +160,7 @@ public class YululiCommand extends Chat {
                 builder.setColor(Color.RED);
             }
 
-            getTextChannel().sendMessage(builder.build()).queue();
+            getTextChannel().sendMessageEmbeds(builder.build()).queue();
             return;
         }
 
@@ -173,7 +173,7 @@ public class YululiCommand extends Chat {
             builder.setThumbnail("https://nana-bot.n7mn.xyz/poti/body.png");
             builder.setImage(imageDataList.get(i).getImageURL());
 
-            getTextChannel().sendMessage(builder.build()).queue();
+            getTextChannel().sendMessageEmbeds(builder.build()).queue();
             return;
         }
 
@@ -186,7 +186,7 @@ public class YululiCommand extends Chat {
             builder.setThumbnail("https://nana-bot.n7mn.xyz/kuretiki/body.png");
             builder.setImage(imageDataList.get(i).getImageURL());
 
-            getTextChannel().sendMessage(builder.build()).queue();
+            getTextChannel().sendMessageEmbeds(builder.build()).queue();
             return;
         }
 
@@ -200,7 +200,7 @@ public class YululiCommand extends Chat {
             builder.setThumbnail("https://nana-bot.n7mn.xyz/VjYrK6z9_400x400.jpg");
             builder.setImage(imageDataList.get(i).getImageURL());
 
-            getTextChannel().sendMessage(builder.build()).queue();
+            getTextChannel().sendMessageEmbeds(builder.build()).queue();
 
         }
 
@@ -213,7 +213,7 @@ public class YululiCommand extends Chat {
             builder.setThumbnail("https://nana-bot.n7mn.xyz/VjYrK6z9_400x400.jpg");
             builder.setImage(imageDataList.get(i).getImageURL());
 
-            getTextChannel().sendMessage(builder.build()).queue();
+            getTextChannel().sendMessageEmbeds(builder.build()).queue();
         }
 
         if (getMessageText().toLowerCase().equals("n.fuck")){
@@ -223,7 +223,7 @@ public class YululiCommand extends Chat {
             builder.setTitle(imageDataList.get(i).getDescription());
             builder.setDescription(imageDataList.get(i).getImageURL());
 
-            getTextChannel().sendMessage(builder.build()).queue();
+            getTextChannel().sendMessageEmbeds(builder.build()).queue();
         }
 
         if (getMessageText().toLowerCase().equals("n.lost") || getMessageText().toLowerCase().equals("n.hoopless") || getMessageText().toLowerCase().equals("n.acrylicstyle") || getMessageText().toLowerCase().equals("n.acrylic_style")){

--- a/src/main/java/xyz/n7mn/dev/Command/money/MoneyUtil.java
+++ b/src/main/java/xyz/n7mn/dev/Command/money/MoneyUtil.java
@@ -1,0 +1,23 @@
+package xyz.n7mn.dev.Command.money;
+
+public class MoneyUtil {
+    public static long multiply(long x, double y) {
+        return Math.round((x * y));
+    }
+
+    public static long add(long x, long y, boolean maxValue) {
+        try {
+            return Math.addExact(x, y);
+        } catch (ArithmeticException ex) {
+            return maxValue ? Long.MAX_VALUE : Long.MIN_VALUE;
+        }
+    }
+
+    public static long subtract(long x, long y, boolean maxValue) {
+        try {
+            return Math.subtractExact(x, y);
+        } catch (ArithmeticException ex) {
+            return maxValue ? Long.MAX_VALUE : Long.MIN_VALUE;
+        }
+    }
+}

--- a/src/main/java/xyz/n7mn/dev/Command/music/PlayerManager.java
+++ b/src/main/java/xyz/n7mn/dev/Command/music/PlayerManager.java
@@ -17,8 +17,6 @@ public class PlayerManager {
     private static PlayerManager INSTANCE;
     private final AudioPlayerManager playerManager;
     private final Map<Long,GuildMusicManager> musicManagers;
-    private Timer timer = new Timer();
-    private List<String> repeatGuildIdList = Collections.synchronizedList(new ArrayList<>());
 
     private PlayerManager() {
         this.musicManagers = new HashMap<>();
@@ -40,58 +38,6 @@ public class PlayerManager {
         guild.getAudioManager().setSendingHandler(musicManager.getSendHandler());
 
         return musicManager;
-
-    }
-
-
-    public void Repeat(TextChannel channel){
-        boolean rep = false;
-
-        for (String guildId : repeatGuildIdList){
-            if (guildId.equals(channel.getGuild().getId())){
-                rep = true;
-                repeatGuildIdList.remove(guildId);
-                break;
-            }
-        }
-
-        if (rep){
-            channel.sendMessage("1曲ループモードをやめましたっ！").queue();
-        } else {
-            channel.sendMessage("1曲ループモードになりましたっ！").queue();
-            repeatGuildIdList.add(channel.getGuild().getId());
-        }
-
-        GuildMusicManager musicManager = getGuildMusicManager(channel.getGuild());
-        AudioPlayer player = musicManager.player;
-
-        long time = player.getPlayingTrack().getInfo().length - player.getPlayingTrack().getPosition();
-
-        TimerTask task = new TimerTask() {
-            @Override
-            public void run() {
-                boolean flag = false;
-                for (String repeat : repeatGuildIdList){
-                    if (repeat.equals(channel.getGuild().getId())){
-                        flag = true;
-                        break;
-                    }
-
-                }
-
-                if (!flag){
-                    this.cancel();
-                    return;
-                }
-                musicManager.scheduler.queue(player.getPlayingTrack().makeClone());
-            }
-        };
-
-        if (!rep){
-            timer.schedule(task, time, player.getPlayingTrack().getInfo().length);
-        } else {
-            timer.cancel();
-        }
 
     }
 

--- a/src/main/java/xyz/n7mn/dev/Command/music/TrackScheduler.java
+++ b/src/main/java/xyz/n7mn/dev/Command/music/TrackScheduler.java
@@ -14,6 +14,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 public class TrackScheduler extends AudioEventAdapter {
     private final AudioPlayer player;
     private final BlockingQueue<AudioTrack> queue;
+    public boolean repeat = false;
 
     /**
      * @param player The audio player this scheduler uses
@@ -46,12 +47,23 @@ public class TrackScheduler extends AudioEventAdapter {
         player.startTrack(queue.poll(), false);
     }
 
+    public void nextTrack(AudioTrack audioTrack) {
+        player.startTrack(audioTrack.makeClone(), false);
+    }
+
     @Override
     public void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
         // Only start the next track if the end reason is suitable for it (FINISHED or LOAD_FAILED)
-        if (endReason.mayStartNext) {
-            nextTrack();
+        if (endReason == AudioTrackEndReason.FINISHED && repeat) {
+            nextTrack(track);
         }
 
+        if (endReason.mayStartNext) {
+            if (repeat) {
+                nextTrack(track);
+            } else {
+                nextTrack();
+            }
+        }
     }
 }

--- a/src/main/java/xyz/n7mn/dev/EarthquakeListener.java
+++ b/src/main/java/xyz/n7mn/dev/EarthquakeListener.java
@@ -174,7 +174,7 @@ public class EarthquakeListener {
                         if (debugMode){
                             builder.setFooter(sdf.format(new Date()) + "に送信しました。");
                             User user = jda.getUserById("529463370089234466");
-                            user.openPrivateChannel().complete().sendMessage(builder.build()).queue();
+                            user.openPrivateChannel().complete().sendMessageEmbeds(builder.build()).queue();
                             System.out.println("デバッグ送信完了");
                             return;
                         }
@@ -197,9 +197,9 @@ public class EarthquakeListener {
                                                     if (textChannelById.canTalk()){
                                                         builder.setFooter(sdf.format(new Date()) + "に送信しました。");
                                                         if (!finalIsMoreMode){
-                                                            textChannelById.sendMessage(builder.build()).queue();
+                                                            textChannelById.sendMessageEmbeds(builder.build()).queue();
                                                         } else {
-                                                            textChannelById.sendMessage("※ 広範囲の地震のため\n  詳細な地震情報はテキストファイルになっております。").embed(builder2).queue();
+                                                            textChannelById.sendMessage("※ 広範囲の地震のため\n  詳細な地震情報はテキストファイルになっております。").setEmbeds(builder2).queue();
                                                             textChannelById.sendFile(new File("./jisin.txt")).queue();
                                                         }
 

--- a/src/main/java/xyz/n7mn/dev/EventListener.java
+++ b/src/main/java/xyz/n7mn/dev/EventListener.java
@@ -2,12 +2,10 @@ package xyz.n7mn.dev;
 
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.*;
-import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.api.events.ReadyEvent;
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
 import net.dv8tion.jda.api.events.guild.GuildLeaveEvent;
 import net.dv8tion.jda.api.events.guild.voice.GenericGuildVoiceEvent;
-import net.dv8tion.jda.api.events.message.MessageDeleteEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageDeleteEvent;
 import net.dv8tion.jda.api.events.message.guild.react.GuildMessageReactionAddEvent;
@@ -34,7 +32,7 @@ import java.util.List;
 
 public class EventListener extends ListenerAdapter {
     private static Database database = null;
-    private Earthquake earthquake = new Earthquake();
+    private final Earthquake earthquake = new Earthquake();
 
     @Override
     public void onGenericGuildVoice(@NotNull GenericGuildVoiceEvent event) {
@@ -91,14 +89,14 @@ public class EventListener extends ListenerAdapter {
                         builder.setTitle("えらー",message.getJumpUrl());
                         builder.setDescription("投票済みの選択肢ですっ！");
                         builder.setColor(Color.RED);
-                        privateChannel.sendMessage(builder.build()).queue();
+                        privateChannel.sendMessageEmbeds(builder.build()).queue();
                         return;
                     }
                 }
                 builder.setTitle("投票完了っ",message.getJumpUrl());
                 builder.setDescription(event.getReactionEmote().getEmoji() + "に投票しました！");
                 builder.setColor(Color.GREEN);
-                privateChannel.sendMessage(builder.build()).queue();
+                privateChannel.sendMessageEmbeds(builder.build()).queue();
 
                 VoteSystem.addReaction(message, event.getMember(), event.getReaction().getReactionEmote().getEmoji());
             }
@@ -151,7 +149,7 @@ public class EventListener extends ListenerAdapter {
             builder.addField("内容", event.getMessage().getContentRaw(), false);
             builder.addField("メッセージリンクURL", event.getMessage().getJumpUrl(), false);
 
-            nana.openPrivateChannel().complete().sendMessage(builder.build()).queue();
+            nana.openPrivateChannel().complete().sendMessageEmbeds(builder.build()).queue();
 
             Message message = event.getMessage();
 

--- a/src/main/java/xyz/n7mn/dev/NanamiFunction.java
+++ b/src/main/java/xyz/n7mn/dev/NanamiFunction.java
@@ -19,7 +19,7 @@ import java.util.regex.Pattern;
 
 public class NanamiFunction {
 
-    private static String ver = "1.4.7-fix1";
+    private static String ver = "1.4.7-fix2";
 
     public static String getVersion(){
         return ver;
@@ -231,7 +231,7 @@ public class NanamiFunction {
             }
 
             builder.setColor(Color.GREEN);
-            message1.editMessage(sb.toString()).embed(builder.build()).queue(message2 -> {
+            message1.editMessage(sb.toString()).setEmbeds(builder.build()).queue(message2 -> {
                 message2.addReaction("\u2705").queue();
             });
 

--- a/src/main/java/xyz/n7mn/dev/adminCommand/CheckServer.java
+++ b/src/main/java/xyz/n7mn/dev/adminCommand/CheckServer.java
@@ -138,10 +138,10 @@ public class CheckServer extends DMInterface{
             }
             builder4.addField((in + 1) + "ページ目", buffer3.toString(), false);
 
-            getMessage().getPrivateChannel().sendMessage(builder.build()).queue();
-            getMessage().getPrivateChannel().sendMessage(builder2.build()).queue();
-            getMessage().getPrivateChannel().sendMessage(builder3.build()).queue();
-            getMessage().getPrivateChannel().sendMessage(builder4.build()).queue();
+            getMessage().getPrivateChannel().sendMessageEmbeds(builder.build()).queue();
+            getMessage().getPrivateChannel().sendMessageEmbeds(builder2.build()).queue();
+            getMessage().getPrivateChannel().sendMessageEmbeds(builder3.build()).queue();
+            getMessage().getPrivateChannel().sendMessageEmbeds(builder4.build()).queue();
         }
     }
 }


### PR DESCRIPTION
# カジノ系 (オーバーフロー系)
- カジノのFX、Payコマンド、おみくじ系がlongをオーバーフローしてマイナスになる可能性があるので修正
- カジノのFXのお金のアップデートが適用されなかったので修正
# その他 (JDA、ミュージック系)
- リピート系が謎の仕組みだったので多分効率化しました～！
- JDAのバージョンを5.0.0にアップデートできるようにするために `sendMessageEmbeds` 系を使うように変更しました 